### PR TITLE
Update contract bindings, fix root index for claimgen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,9 @@ go 1.22.2
 toolchain go1.22.3
 
 require (
-	github.com/Layr-Labs/eigenlayer-contracts v0.3.0-rc1-holesky-preprod-payments
-	github.com/Layr-Labs/eigenlayer-payment-proofs v0.0.0-20240516162452-b99f35e24ff6
+	github.com/Layr-Labs/eigenlayer-contracts v0.2.5-mainnet-m2-minor-eigenpod-upgrade.0.20240523155341-ae95614b048a
+	github.com/Layr-Labs/eigenlayer-payment-proofs v0.0.0-20240523160126-3b2048925287
 	github.com/ethereum/go-ethereum v1.14.0
-	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.31.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,12 @@ github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjv
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/Layr-Labs/eigenlayer-contracts v0.2.5-mainnet-m2-minor-eigenpod-upgrade.0.20240523155341-ae95614b048a h1:ZGdezPCEGlE2j365mVkpCkueXrvOXbfl0intPfVoqY0=
+github.com/Layr-Labs/eigenlayer-contracts v0.2.5-mainnet-m2-minor-eigenpod-upgrade.0.20240523155341-ae95614b048a/go.mod h1:+Ip6I5FpoU3tswZvpzafoURQGa5c2x0XqvD8y2+yWl0=
 github.com/Layr-Labs/eigenlayer-contracts v0.3.0-rc1-holesky-preprod-payments h1:0/83HlyTMRytyqYMBRY/MSzK8Ot819lX7stXPvZvWKk=
 github.com/Layr-Labs/eigenlayer-contracts v0.3.0-rc1-holesky-preprod-payments/go.mod h1:+Ip6I5FpoU3tswZvpzafoURQGa5c2x0XqvD8y2+yWl0=
-github.com/Layr-Labs/eigenlayer-payment-proofs v0.0.0-20240516162452-b99f35e24ff6 h1:ZSM8E4QwqB6GRCrUqDA9Wda228ABrjWjdEzntTJO4YQ=
-github.com/Layr-Labs/eigenlayer-payment-proofs v0.0.0-20240516162452-b99f35e24ff6/go.mod h1:loHmnp5jHZifnG2t1KQq504MfIYoYgLdSELFJWCqv34=
+github.com/Layr-Labs/eigenlayer-payment-proofs v0.0.0-20240523160126-3b2048925287 h1:t+KAMnSqdxEi4MsUzZOI4sGvfM3HBJSediXkCyKGup0=
+github.com/Layr-Labs/eigenlayer-payment-proofs v0.0.0-20240523160126-3b2048925287/go.mod h1:EeICFfpqXmJqUMwYJ/yKUx9Fv1dxrS00oL1Nfae6CAY=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=

--- a/mocks/transactor.go
+++ b/mocks/transactor.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -30,6 +31,36 @@ func (_m *Transactor) CurrPaymentCalculationEndTimestamp() (uint32, error) {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(uint32)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetNumberOfPublishedRoots provides a mock function with given fields:
+func (_m *Transactor) GetNumberOfPublishedRoots() (*big.Int, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNumberOfPublishedRoots")
+	}
+
+	var r0 *big.Int
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*big.Int, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func() error); ok {

--- a/pkg/proofDataFetcher/httpProofDataFetcher/fetcher.go
+++ b/pkg/proofDataFetcher/httpProofDataFetcher/fetcher.go
@@ -38,6 +38,7 @@ func NewHttpProofDataFetcher(
 }
 
 func (h *HttpProofDataFetcher) FetchClaimAmountsForDate(date string) (*proofDataFetcher.PaymentProofData, error) {
+	h.logger.Sugar().Debug(fmt.Sprintf("Fetching claim amounts for date '%s'", date), zap.String("date", date))
 	fullUrl := h.buildClaimAmountsUrl(date)
 
 	rawBody, err := h.handleRequest(fullUrl)

--- a/pkg/services/transactor.go
+++ b/pkg/services/transactor.go
@@ -7,10 +7,12 @@ import (
 	"github.com/Layr-Labs/eigenlayer-payment-updater/pkg/chainClient"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"math/big"
 )
 
 type Transactor interface {
 	CurrPaymentCalculationEndTimestamp() (uint32, error)
+	GetNumberOfPublishedRoots() (*big.Int, error)
 	GetRootIndex(root [32]byte) (uint32, error)
 	SubmitRoot(ctx context.Context, root [32]byte, paymentsUnixTimestamp uint32) error
 }
@@ -41,6 +43,10 @@ func NewTransactor(chainClient *chainClient.ChainClient, paymentCoordinatorAddre
 
 func (t *TransactorImpl) CurrPaymentCalculationEndTimestamp() (uint32, error) {
 	return t.PaymentCoordinatorCaller.CurrPaymentCalculationEndTimestamp(&bind.CallOpts{})
+}
+
+func (t *TransactorImpl) GetNumberOfPublishedRoots() (*big.Int, error) {
+	return t.PaymentCoordinatorCaller.GetDistributionRootsLength(&bind.CallOpts{})
 }
 
 func (s *TransactorImpl) GetRootIndex(root [32]byte) (uint32, error) {


### PR DESCRIPTION
- Bump contracts version to get access to `GetDistributionRootsLength`
- Fix claimgen logic to pass the correct value for root index