### PR TITLE
Fix viper pflags parsing

### DIFF
--- a/cmd/claim.go
+++ b/cmd/claim.go
@@ -178,15 +178,9 @@ var claimCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(claimCmd)
 
-	claimCmd.Flags().String("environment", "dev", "The environment to use")
-	claimCmd.Flags().String("network", "localnet", "Which network to use")
-	claimCmd.Flags().String("rpc-url", "", "https://ethereum-holesky-rpc.publicnode.com")
-	claimCmd.Flags().String("private-key", "", "An ethereum private key")
-	claimCmd.Flags().String("rewards-coordinator-address", "0x56c119bD92Af45eb74443ab14D4e93B7f5C67896", "Ethereum address of the rewards coordinator contract")
 	claimCmd.Flags().String("output", "", "File to write output json to")
 	claimCmd.Flags().String("earner-address", "", "Address of the earner")
 	claimCmd.Flags().StringSlice("tokens", []string{}, "List of token addresses")
-	claimCmd.Flags().String("proof-store-base-url", "", "HTTP base url where data is stored")
 	claimCmd.Flags().String("claim-timestamp", "", "YYYY-MM-DD - Timestamp of the rewards root to claim against")
 	claimCmd.Flags().Bool("submit-claim", false, "Post the claim to the rewards coordinator")
 

--- a/cmd/distribution.go
+++ b/cmd/distribution.go
@@ -125,13 +125,7 @@ var distributionCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(distributionCmd)
 
-	distributionCmd.Flags().String("environment", "dev", "The environment to use")
-	distributionCmd.Flags().String("network", "localnet", "Which network to use")
-	distributionCmd.Flags().String("rpc-url", "", "https://ethereum-holesky-rpc.publicnode.com")
-	distributionCmd.Flags().String("private-key", "", "An ethereum private key")
-	distributionCmd.Flags().String("rewards-coordinator-address", "0x56c119bD92Af45eb74443ab14D4e93B7f5C67896", "Ethereum address of the rewards coordinator contract")
 	distributionCmd.Flags().String("output", "", "File to write output json to")
-	distributionCmd.Flags().String("proof-store-base-url", "", "HTTP base url where data is stored")
 
 	distributionCmd.Flags().VisitAll(func(f *pflag.Flag) {
 		if err := viper.BindPFlag(config.KebabToSnakeCase(f.Name), f); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,12 @@ func init() {
 	rootCmd.PersistentFlags().String("dd-statsd-url", "", "URL to use for DataDog StatsD. If empty, DD_DOGSTATSD_URL will be used")
 	rootCmd.PersistentFlags().Bool("enable-statsd", true, "Enable/disable statsd metrics collection")
 	rootCmd.PersistentFlags().Bool("enable-tracing", true, "Enable/disable tracing")
+	rootCmd.PersistentFlags().String("rpc-url", "", "https://ethereum-holesky-rpc.publicnode.com")
+	rootCmd.PersistentFlags().String("environment", "dev", "The environment to use")
+	rootCmd.PersistentFlags().String("network", "localnet", "Which network to use")
+	rootCmd.PersistentFlags().String("private-key", "", "An ethereum private key")
+	rootCmd.PersistentFlags().String("rewards-coordinator-address", "0x56c119bD92Af45eb74443ab14D4e93B7f5C67896", "Ethereum address of the rewards coordinator contract")
+	rootCmd.PersistentFlags().String("proof-store-base-url", "", "HTTP base url where data is stored")
 
 	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		viper.BindPFlag(config.KebabToSnakeCase(f.Name), f)

--- a/cmd/updater.go
+++ b/cmd/updater.go
@@ -108,13 +108,6 @@ var updaterCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(updaterCmd)
 
-	updaterCmd.Flags().String("environment", "dev", "The environment to use")
-	updaterCmd.Flags().String("network", "localnet", "Which network to use")
-	updaterCmd.Flags().String("rpc-url", "", "https://ethereum-holesky-rpc.publicnode.com")
-	updaterCmd.Flags().String("private-key", "", "An ethereum private key")
-	updaterCmd.Flags().String("rewards-coordinator-address", "0x56c119bD92Af45eb74443ab14D4e93B7f5C67896", "Ethereum address of the rewards coordinator contract")
-	updaterCmd.Flags().String("proof-store-base-url", "", "HTTP base url where data is stored")
-
 	updaterCmd.Flags().VisitAll(func(f *pflag.Flag) {
 		if err := viper.BindPFlag(config.KebabToSnakeCase(f.Name), f); err != nil {
 			fmt.Printf("Failed to bind flag '%s' - %+v\n", f.Name, err)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -112,13 +112,6 @@ var validateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(validateCmd)
 
-	validateCmd.Flags().String("environment", "dev", "The environment to use")
-	validateCmd.Flags().String("network", "localnet", "Which network to use")
-	validateCmd.Flags().String("rpc-url", "", "https://ethereum-holesky-rpc.publicnode.com")
-	validateCmd.Flags().String("private-key", "", "An ethereum private key")
-	validateCmd.Flags().String("rewards-coordinator-address", "0x56c119bD92Af45eb74443ab14D4e93B7f5C67896", "Ethereum address of the rewards coordinator contract")
-	validateCmd.Flags().String("proof-store-base-url", "", "HTTP base url where data is stored")
-
 	validateCmd.Flags().VisitAll(func(f *pflag.Flag) {
 		if err := viper.BindPFlag(config.KebabToSnakeCase(f.Name), f); err != nil {
 			fmt.Printf("Failed to bind flag '%s' - %+v\n", f.Name, err)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,29 +1,16 @@
 services:
-  updater:
-    image: eigenlayer-rewards-updater:latest
-    build:
-      dockerfile: Dockerfile
-    volumes:
-      - "$PWD:/etc/eigenlayer-rewards-updater"
-    command:
-      - "updater"
   updater-cli-args:
     image: eigenlayer-rewards-updater:latest
     build:
       dockerfile: Dockerfile
-    # ----
-    # Volume mount is only required if you wish to provide a custom config file
-    # ----
-    # volumes:
-    #   - "$PWD:/etc/eigenlayer-rewards-updater"
     command:
       - "updater"
       - "--debug=true"
       - "--enable-statsd=false"
       - "--enable-tracing=false"
-      - "--environment='preprod'"
-      - "--network='holesky'"
-      - "--rpc-url='https://ethereum-holesky-rpc.publicnode.com'"
-      - "--proof-store-url='https://eigenpayments-dev.s3.us-east-2.amazonaws.com'"
-      - "--private-key='<ethereum private key (hex string, not prefixed with 0x)>'"
-      - "--rewards-coordinator-address='<contract address>'"
+      - "--environment=testnet"
+      - "--network=holesky"
+      - "--rpc-url=https://ethereum-holesky-rpc.publicnode.com"
+      - "--proof-store-base-url=https://eigenlabs-rewards-testnet-holesky.s3.amazonaws.com"
+      - "--private-key=<ethereum private key (hex string, not prefixed with 0x)>"
+      - "--rewards-coordinator-address=0xAcc1fb458a1317E886dB376Fc8141540537E68fE"


### PR DESCRIPTION
Related to this thread: https://github.com/spf13/viper/issues/375

When you have the same flag across multiple commands, parsing ends up behaving in ways you would not expect it to. Solution for now is to move all common flags up into the root command to be parsed only once.