### PR TITLE
Properly decode/encode root when updating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/DataDog/go-libddwaf/v2 v2.4.2 // indirect
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.2 // indirect
-	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
+	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.14-0.20241125201443-e68b50c3a470
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-0
 github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQAPooM+8EVqv9w2bL4OytgY=
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
+github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.14-0.20241125201443-e68b50c3a470 h1:xLZ56DyrFy4CpjM9wHR4gOxxbSn1F9qYrZRkfV2V3Ic=
+github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.14-0.20241125201443-e68b50c3a470/go.mod h1:szcJU28Y/X8EPCsPesY06Z3Bx7eUagwEEogLiqqxo38=
 github.com/Layr-Labs/protocol-apis v0.1.0-beta.1.0.20241031143701-1007e0c3775c h1:jgImTwABd+bgblTHy4J/nqwE2cDIAHZ3zGNgFpS9P6s=
 github.com/Layr-Labs/protocol-apis v0.1.0-beta.1.0.20241031143701-1007e0c3775c/go.mod h1:prNA2/mLO5vpMZ2q78Nsn0m97wm28uiRnwO+/yOxigk=
 github.com/Layr-Labs/protocol-apis v0.1.0-beta.3.0.20241122223729-1734c60ac737 h1:I/0YAw2ue150YuLNavErIQ4t7yoTDuH3nqZkOS7RTjg=

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -3,6 +3,7 @@ package updater_test
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/utils"
 	"github.com/Layr-Labs/eigenlayer-rewards-updater/internal/logger"
 	"github.com/Layr-Labs/eigenlayer-rewards-updater/internal/metrics"
 	"github.com/Layr-Labs/eigenlayer-rewards-updater/mocks"
@@ -69,10 +70,9 @@ func TestUpdaterUpdate(t *testing.T) {
 
 	expectedSnapshotDateTime, _ := time.Parse(time.DateOnly, expectedSnapshotDate)
 
-	expectedRootBytes := [32]byte{}
-	copy(expectedRootBytes[:], []byte(expectedRoot))
+	expectedRootBytes, _ := utils.ConvertStringToBytes(expectedRoot)
 
-	mockTransactor.On("SubmitRoot", mock.Anything, expectedRootBytes, uint32(expectedSnapshotDateTime.Unix())).Return(nil)
+	mockTransactor.On("SubmitRoot", mock.Anything, [32]byte(expectedRootBytes), uint32(expectedSnapshotDateTime.Unix())).Return(nil)
 
 	updatedRoot, err := updater.Update(ctx)
 	assert.Nil(t, err)


### PR DESCRIPTION
Root string from the sidecar was getting copied to the `[32]byte()` variable with the leading `0x` which is problematic.